### PR TITLE
add `gather_table_stats()`

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -140,11 +140,11 @@ get_first_non_archived_year <- function(conn) {
 #' @param table Chaine de caractère indiquant le nom d'une table
 #' @references https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_STATS.html#GUID-CA6A56B9-0540-45E9-B1D7-D78769B7714C
 gather_table_stats <- function(conn, table) {
-  user <- dbGetQuery(conn, "SELECT user FROM dual;")
+  user <- dbGetQuery(conn, "SELECT user FROM dual")
   user <- dbQuoteIdentifier(conn, user$USER)
   dbExecute(
     conn,
-    "BEGIN DBMS_STATS.GATHER_TABLE_STATS(?, ?); END;",
-    params = list(user, table)
+    "BEGIN DBMS_STATS.GATHER_TABLE_STATS(:1, :2); END;",
+    data = data.frame(user, table)
   )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -134,3 +134,17 @@ get_first_non_archived_year <- function(conn) {
     as.character(max(as.numeric(archived_years)) + 1)
   return(first_non_archived_year)
 }
+
+#' Récupération des statistiques des tables
+#' @param conn Connexion à la base de données
+#' @param table Chaine de caractère indiquant le nom d'une table
+#' @references https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_STATS.html#GUID-CA6A56B9-0540-45E9-B1D7-D78769B7714C
+gather_table_stats <- function(conn, table) {
+  user <- dbGetQuery(con, "SELECT user FROM dual;")
+  user <- dbQuoteIdentifier(con, user$USER)
+  dbExecute(
+    conn,
+    "BEGIN DBMS_STATS.GATHER_TABLE_STATS(?, ?); END;",
+    params = list(user, table)
+  )
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -140,8 +140,8 @@ get_first_non_archived_year <- function(conn) {
 #' @param table Chaine de caractère indiquant le nom d'une table
 #' @references https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_STATS.html#GUID-CA6A56B9-0540-45E9-B1D7-D78769B7714C
 gather_table_stats <- function(conn, table) {
-  user <- dbGetQuery(con, "SELECT user FROM dual;")
-  user <- dbQuoteIdentifier(con, user$USER)
+  user <- dbGetQuery(conn, "SELECT user FROM dual;")
+  user <- dbQuoteIdentifier(conn, user$USER)
   dbExecute(
     conn,
     "BEGIN DBMS_STATS.GATHER_TABLE_STATS(?, ?); END;",


### PR DESCRIPTION
Je mets en draft car nécessite [quelques ajustements](https://soeiro.gitlab.io/pepidoc/logiciels.html#roracle-versus-odbc) pour `{ROracle}` (mais fonctionne avec `{odbc}`) : pas de `;`, `?` -> `:n` `params` -> `data`

On pourra utiliser `gather_table_stats()` dans les fonctions d'extraction après les `dbWriteTable()` des tables données par les utilisateurs (`patients_ids`, etc.)

Voir aussi https://soeiro.gitlab.io/pepidoc/logiciels.html#statistiques-des-tables